### PR TITLE
Add offline offline fallback and service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -1318,9 +1318,9 @@
                 } else {
                     showNotification('Password reset email sent.');
                 }
-            });
+        });
 
-            // --- Profile Modal Listeners ---
+        // --- Profile Modal Listeners ---
             openProfileModalBtn.addEventListener('click', openProfileModal);
             closeProfileModalBtn.addEventListener('click', () => profileModal.classList.add('hidden'));
             
@@ -1362,6 +1362,13 @@
             });
 
         });
+    </script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('/service-worker.js');
+            });
+        }
     </script>
 </body>
 </html>

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; padding: 2rem; }
+  </style>
+</head>
+<body>
+  <h1>You're Offline</h1>
+  <p>The application is currently unavailable because you are not connected to the internet.</p>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,16 @@
+const CACHE_NAME = 'offline-cache-v1';
+const OFFLINE_URL = 'offline.html';
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.add(OFFLINE_URL))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(OFFLINE_URL))
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add offline.html page to show when app is offline
- create service worker caching offline.html and serving it when fetch fails
- register service worker in index.html

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689367385a5c83259cf2ce924d69286d