### PR TITLE
Add service worker for offline caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -1363,5 +1363,12 @@
 
         });
     </script>
+<script>
+    if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+            navigator.serviceWorker.register('/service-worker.js');
+        });
+    }
+</script>
 </body>
 </html>

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Offline</title>
+    <style>
+        body {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+            font-family: Arial, sans-serif;
+            text-align: center;
+            background-color: #f3f4f6;
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <div>
+        <h1>You are offline</h1>
+        <p>Please check your internet connection.</p>
+    </div>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,49 @@
+const CACHE_NAME = 'poppymarket-cache-v1';
+const OFFLINE_URL = '/offline.html';
+const ASSETS = [
+  '/',
+  '/index.html',
+  OFFLINE_URL,
+  'https://cdn.tailwindcss.com',
+  'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => {
+      return cache.addAll(ASSETS.map(url => new Request(url, { mode: 'no-cors' })));
+    })
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+  event.respondWith(
+    caches.match(event.request).then(cachedResponse => {
+      const fetchPromise = fetch(event.request).then(networkResponse => {
+        caches.open(CACHE_NAME).then(cache => {
+          cache.put(event.request, networkResponse.clone());
+        });
+        return networkResponse;
+      }).catch(() => {
+        if (cachedResponse) {
+          return cachedResponse;
+        }
+        if (event.request.mode === 'navigate') {
+          return caches.match(OFFLINE_URL);
+        }
+      });
+      return cachedResponse || fetchPromise;
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add service worker to cache key static assets and serve offline fallback
- register the service worker from the main page
- provide a simple offline page for connectivity loss

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689367306f708325ae3b0cceba80fb68